### PR TITLE
Removing wrong trailling comma

### DIFF
--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -43,7 +43,7 @@
 		"message": "Salvar"
 	},
 	"enqueue": {
-		"message": "Colocar na fila",
+		"message": "Colocar na fila"
 	},
 	"copyUrl": {
 		"message": "Copiar URL"


### PR DESCRIPTION
Chrome Web Store was showing an error when a user tried to install.
