### PR TITLE
Include files in key directory with placeholder text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 Deploy/
 Streamus *.zip
 Streamus v*/
-key/
 
 ##################
 ## Node

--- a/src/js/background/key/youTubeAPI.js
+++ b/src/js/background/key/youTubeAPI.js
@@ -1,0 +1,3 @@
+define(function () {
+  return 'API_KEY_HERE';
+});


### PR DESCRIPTION
Hi there, awesome work on the extension - use it daily!

Currently the extension will not run after a fresh clone as RequireJS is throwing an error when trying to load the YouTube API key (which is intentionally excluded from git). The error message wasn't immediately obvious to me, and I had to do a decent amount of digging before I figured this one out.

Including the file with some placeholder text for the API key should hopefully make things a little clearer. Perhaps also amend the readme with info on creating an API key too. I'm not sure if you're actively seeking contributions, but having a low barrier to entry can't be a bad thing! :-)

Cheers,

Ryan
