### PR TITLE
Add correct handling of special csv characters

### DIFF
--- a/src/js/common/utility.js
+++ b/src/js/common/utility.js
@@ -92,9 +92,15 @@
         for (var i = 0; i < array.length; i++) {
             var line = '';
             for (var index in array[i]) {
+                var csval = array[i][index];
                 if (line !== '') line += ',';
 
-                line += array[i][index];
+                if (/("|,|\n)/.test(csval)) {
+                    // enclose value in double quotes, escaping any pre-existing
+                    line += '"' + csval.replace('"', '""') + '"';
+                } else {
+                    line += csval;
+                }
             }
 
             str += line + '\r\n';


### PR DESCRIPTION
At the moment, exporting a playlist as CSV format will produce a bad value if any of video's titles (or other properties) contain a special CSV character e.g:

`deadmau5 - Sometimes Things Get, Whatever (HQ),GOzwOeONBhQ,https://youtu.be/GOzwOeONBhQ`

Because the title contains a comma, it needs to be enclosed in double quotes to avoid being treated as two separate values:

`"deadmau5 - Sometimes Things Get, Whatever (HQ)",GOzwOeONBhQ,https://youtu.be/GOzwOeONBhQ`

I'm also escaping any existing double quotes before enclosing, as this is also a requirement of the format. If you're interested, I found the standard csv requirements [here](http://tools.ietf.org/html/rfc4180).

Thanks!
