### PR TITLE
Force UI to full size if loaded in new tab

### DIFF
--- a/src/less/foreground.less
+++ b/src/less/foreground.less
@@ -32,13 +32,13 @@
 @import "volumeArea";
 
 //  Force UI to full size if Streamus has been loaded into a tab by detecting min-width/min-height greater than maximum extension width/height.
-/*@media (min-width:650px) and (min-height:490px) {
+@media (min-width:650px) and (min-height:490px) {
     html,
     body {
         width: 100% !important;
         height: 100% !important;
     }
-}*/
+}
 
 body {
     //  Default dimensions of Streamus as a browser extension


### PR DESCRIPTION
Tiny one this one!

Not sure if I'm missing something (sadly I can't see the bug you were fixing when you originally committed this), but it looks like these lines may have been left commented out by mistake? Without them Streamus won't resize to take up the full window on a new tab.

If I've missed something and you were working on this anyway then feel free to just close this PR!

Thanks